### PR TITLE
ページ遷移の判定を修正

### DIFF
--- a/entrypoints/github.content/index.tsx
+++ b/entrypoints/github.content/index.tsx
@@ -39,9 +39,14 @@ export default defineContentScript({
 
     await executeIfMatched(location)
 
-    ctx.addEventListener(window, "wxt:locationchange", async ({ newUrl }) => {
-      await executeIfMatched(newUrl)
-    })
+    ctx.addEventListener(
+      window,
+      "wxt:locationchange",
+      async ({ newUrl, oldUrl }) => {
+        if (oldUrl.pathname === newUrl.pathname) return
+        await executeIfMatched(newUrl)
+      },
+    )
   },
 })
 


### PR DESCRIPTION
差分ページでページ内リンクをクリックした際にボタンが重複して追加されてしまう問題に対応。
パスが変わらなければページ遷移したことにならないように修正。
fix #3 