### PR TITLE
テンプレートの内容を表す識別子を `content` から `source` にリネーム

### DIFF
--- a/entrypoints/github.content/markup.ts
+++ b/entrypoints/github.content/markup.ts
@@ -16,7 +16,7 @@ const getTemplate = async (): Promise<string> => {
     const defaultTemplate = await templatesService.getDefaultTemplate()
 
     if (defaultTemplate) {
-      return defaultTemplate.content
+      return defaultTemplate.source
     }
   } catch (error) {
     console.error("Failed to get default template:", error)

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -45,7 +45,7 @@ const App = () => {
   }
 
   const handleSave = async (
-    data: Pick<Template, "name" | "content">,
+    data: Pick<Template, "name" | "source">,
     isDefault: boolean,
   ) => {
     if (editingTemplate) {

--- a/entrypoints/popup/components/ImportButton.tsx
+++ b/entrypoints/popup/components/ImportButton.tsx
@@ -28,7 +28,7 @@ export const ImportButton = ({
         !data.every(
           (template) =>
             typeof template?.name === "string" &&
-            typeof template?.content === "string",
+            typeof template?.source === "string",
         )
       ) {
         throw new Error("Invalid format")
@@ -39,7 +39,7 @@ export const ImportButton = ({
           ({
             id: crypto.randomUUID(),
             name: template.name,
-            content: template.content,
+            source: template.source,
             createdAt: Date.now(),
             updatedAt: Date.now(),
           }) as const satisfies Template,

--- a/entrypoints/popup/components/TemplateFormDialog.tsx
+++ b/entrypoints/popup/components/TemplateFormDialog.tsx
@@ -13,7 +13,7 @@ interface TemplateFormDialogProps {
   template: Template | null
   defaultTemplateId: string | null
   onSave: (
-    data: Pick<Template, "name" | "content">,
+    data: Pick<Template, "name" | "source">,
     isDefault: boolean,
   ) => Promise<void>
   onClose: () => void
@@ -22,7 +22,7 @@ interface TemplateFormDialogProps {
 
 interface Errors {
   name?: string
-  content?: string
+  source?: string
   general?: string
 }
 
@@ -35,14 +35,14 @@ export const TemplateFormDialog = ({
 }: TemplateFormDialogProps) => {
   const formId = "template-form"
   const [name, setName] = useState("")
-  const [content, setContent] = useState("")
+  const [source, setSource] = useState("")
   const [isDefault, setIsDefault] = useState(false)
   const [errors, setErrors] = useState<Errors>({})
   const [validated, setValidated] = useState(false)
 
   useEffect(() => {
     setName(template?.name || "")
-    setContent(template?.content || "")
+    setSource(template?.source || "")
     setIsDefault(template?.id === defaultTemplateId)
     setValidated(false)
     setErrors({})
@@ -57,14 +57,14 @@ export const TemplateFormDialog = ({
     if (!name.trim()) {
       newErrors.name = "Template name is required"
     }
-    if (!content.trim()) {
-      newErrors.content = "Template content is required"
+    if (!source.trim()) {
+      newErrors.source = "Template source is required"
     }
 
     try {
-      mustache.parse(content)
+      mustache.parse(source)
     } catch (err) {
-      newErrors.content =
+      newErrors.source =
         err instanceof Error ? err.message : "Invalid Mustache syntax"
     }
 
@@ -77,7 +77,7 @@ export const TemplateFormDialog = ({
       await onSave(
         {
           name: name.trim(),
-          content: content.trim(),
+          source: source.trim(),
         },
         isDefault,
       )
@@ -92,7 +92,7 @@ export const TemplateFormDialog = ({
   const handleClose = () => {
     setValidated(false)
     setName("")
-    setContent("")
+    setSource("")
     setIsDefault(false)
     setErrors({})
     onClose()
@@ -150,23 +150,23 @@ export const TemplateFormDialog = ({
         </div>
         <div style={{ marginBottom: 8 }}>
           <FormControl required>
-            <FormControl.Label>Template content</FormControl.Label>
+            <FormControl.Label>Template source</FormControl.Label>
             <Textarea
-              name="content"
+              name="source"
               rows={10}
               placeholder="{{#hunkList}}&#13;{{#collapseWhitespace}}```{{langId}} {{#isFirst}}filePath={{filePath}}{{/isFirst}} newStart={{newStart}} oldStart={{oldStart}}{{/collapseWhitespace}}&#13;{{{code}}}&#13;```&#13;{{/hunkList}}"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
+              value={source}
+              onChange={(e) => setSource(e.target.value)}
               validationStatus={
-                validated && errors.content ? "error" : undefined
+                validated && errors.source ? "error" : undefined
               }
               block
               resize="vertical"
               style={{ fontFamily: "monospace" }}
             />
-            {validated && errors.content && (
+            {validated && errors.source && (
               <FormControl.Validation variant="error">
-                {errors.content}
+                {errors.source}
               </FormControl.Validation>
             )}
           </FormControl>

--- a/entrypoints/popup/components/TemplateList.tsx
+++ b/entrypoints/popup/components/TemplateList.tsx
@@ -116,7 +116,7 @@ export const TemplateList = ({
                   color: "var(--fgColor-default)",
                 }}
               >
-                {template.content}
+                {template.source}
               </code>
             </pre>
             <Stack

--- a/entrypoints/popup/hooks/useTemplates.ts
+++ b/entrypoints/popup/hooks/useTemplates.ts
@@ -33,13 +33,13 @@ export const useTemplates = () => {
 
   const createTemplate = useCallback(
     async (
-      template: Pick<Template, "name" | "content">,
+      template: Pick<Template, "name" | "source">,
       isDefault?: boolean,
     ) => {
       try {
         const newTemplate = await templatesService.createTemplate(
           template.name,
-          template.content,
+          template.source,
           isDefault,
         )
         await loadTemplates()
@@ -56,14 +56,14 @@ export const useTemplates = () => {
   const updateTemplate = useCallback(
     async (
       id: string,
-      template: Pick<Template, "name" | "content">,
+      template: Pick<Template, "name" | "source">,
       isDefault?: boolean,
     ) => {
       try {
         const updatedTemplate = await templatesService.updateTemplate(
           id,
           template.name,
-          template.content,
+          template.source,
           isDefault,
         )
         await loadTemplates()

--- a/tests/e2e/pages/popup.ts
+++ b/tests/e2e/pages/popup.ts
@@ -23,11 +23,11 @@ export async function openPopup(page: Page, extensionId: string) {
 
     // MARK: - 主要操作
 
-    async createTemplate(name: string, content: string, isDefault = false) {
+    async createTemplate(name: string, source: string, isDefault = false) {
       await this.clickNewButton()
       await this.waitForFormDialog()
       await this.fillTemplateNameInput(name)
-      await this.fillTemplateContentTextArea(content)
+      await this.fillTemplateSourceTextArea(source)
       if (isDefault) {
         await this.checkDefaultCheckbox()
       }
@@ -38,13 +38,13 @@ export async function openPopup(page: Page, extensionId: string) {
     async editTemplate(
       templateName: string,
       newName: string,
-      newContent: string,
+      newSource: string,
       isDefault?: boolean,
     ) {
       await this.clickEditButton(templateName)
       await this.waitForFormDialog()
       await this.fillTemplateNameInput(newName)
-      await this.fillTemplateContentTextArea(newContent)
+      await this.fillTemplateSourceTextArea(newSource)
       if (isDefault !== undefined) {
         if (isDefault) {
           await this.checkDefaultCheckbox()
@@ -63,11 +63,11 @@ export async function openPopup(page: Page, extensionId: string) {
       await this.waitForConfirmDialogToClose()
     },
 
-    async cancelCreateTemplate(name?: string, content?: string) {
+    async cancelCreateTemplate(name?: string, source?: string) {
       await this.clickNewButton()
       await this.waitForFormDialog()
       if (name) await this.fillTemplateNameInput(name)
-      if (content) await this.fillTemplateContentTextArea(content)
+      if (source) await this.fillTemplateSourceTextArea(source)
       await this.clickCancelCreateOrUpdateButton()
       await this.waitForFormDialogToClose()
     },
@@ -75,12 +75,12 @@ export async function openPopup(page: Page, extensionId: string) {
     async cancelEditTemplate(
       templateName: string,
       newName?: string,
-      newContent?: string,
+      newSource?: string,
     ) {
       await this.clickEditButton(templateName)
       await this.waitForFormDialog()
       if (newName) await this.fillTemplateNameInput(newName)
-      if (newContent) await this.fillTemplateContentTextArea(newContent)
+      if (newSource) await this.fillTemplateSourceTextArea(newSource)
       await this.clickCancelCreateOrUpdateButton()
       await this.waitForFormDialogToClose()
     },
@@ -142,9 +142,9 @@ export async function openPopup(page: Page, extensionId: string) {
       await nameInput.fill(name)
     },
 
-    async fillTemplateContentTextArea(content: string) {
-      const contentTextarea = page.locator('textarea[name="content"]')
-      await contentTextarea.fill(content)
+    async fillTemplateSourceTextArea(source: string) {
+      const sourceTextarea = page.locator('textarea[name="source"]')
+      await sourceTextarea.fill(source)
     },
 
     async checkDefaultCheckbox() {

--- a/tests/unit/markup.test.ts
+++ b/tests/unit/markup.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/utils/templatesService", () => ({
     getDefaultTemplate: vi.fn().mockResolvedValue({
       id: "test-template",
       name: "Test Template",
-      content: TEST_TEMPLATE,
+      source: TEST_TEMPLATE,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     }),

--- a/utils/templatesRepo.ts
+++ b/utils/templatesRepo.ts
@@ -4,7 +4,7 @@ import { IDBPDatabase } from "idb"
 export interface Template {
   id: string
   name: string
-  content: string
+  source: string
   createdAt: number
   updatedAt: number
 }

--- a/utils/templatesService.ts
+++ b/utils/templatesService.ts
@@ -14,12 +14,12 @@ export interface TemplatesService {
   /**
    * テンプレートを作成する
    * @param name テンプレートの名前
-   * @param content テンプレートの内容
+   * @param source テンプレートの内容
    * @param isDefault デフォルトとして設定するか
    */
   createTemplate(
     name: string,
-    content: string,
+    source: string,
     isDefault?: boolean,
   ): Promise<Template>
 
@@ -27,13 +27,13 @@ export interface TemplatesService {
    * テンプレートを更新する
    * @param id テンプレート ID
    * @param name テンプレートの名前
-   * @param content テンプレートの内容
+   * @param source テンプレートの内容
    * @param isDefault デフォルトとして設定するか
    */
   updateTemplate(
     id: string,
     name: string,
-    content: string,
+    source: string,
     isDefault?: boolean,
   ): Promise<Template>
 
@@ -74,13 +74,13 @@ const createTemplatesService = (
 
     async createTemplate(
       name: string,
-      content: string,
+      source: string,
       isDefault?: boolean,
     ): Promise<Template> {
       const newTemplate = {
         id: crypto.randomUUID(),
         name,
-        content,
+        source,
         createdAt: Date.now(),
         updatedAt: Date.now(),
       } as const satisfies Template
@@ -109,7 +109,7 @@ const createTemplatesService = (
     async updateTemplate(
       id: string,
       name: string,
-      content: string,
+      source: string,
       isDefault?: boolean,
     ): Promise<Template> {
       const existingTemplate = await templatesRepo.getOne(id)
@@ -121,7 +121,7 @@ const createTemplatesService = (
       const updatedTemplate = {
         ...existingTemplate,
         name,
-        content,
+        source,
         updatedAt: Date.now(),
       } as const satisfies Template
       await templatesRepo.createOrUpdate(updatedTemplate)


### PR DESCRIPTION
resolve #24 