### PR TITLE
テンプレートエンジンを Mustache から Handlebars に移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ GitHub の差分ページでコードをクリップボードにコピーでき�
 ![React](https://img.shields.io/badge/React-19.1.0-61DAFB?style=for-the-badge&logo=react)
 ![WXT](https://img.shields.io/badge/WXT-0.20.7-FF6000?style=for-the-badge&logo=wxt)
 ![Primer](https://img.shields.io/badge/Primer-37.28.0-24292e?style=for-the-badge&logo=github)
-![Mustache](https://img.shields.io/badge/Mustache-4.2.0-000000?style=for-the-badge)
+![Handlebars](https://img.shields.io/badge/Handlebars-4.7.8-000000?style=for-the-badge&logo=handlebarsdotjs)
 
 ## 対応ページ
 
@@ -123,11 +123,11 @@ pnpm test:all
 
 ## テンプレートの記法
 
-Mustache テンプレートエンジンを使用しているため、任意のマークアップのテンプレートを記述できます。
+Handlebars テンプレートエンジンを使用しているため、任意のマークアップのテンプレートを記述できます。
 
 > [!NOTE]
-> Mustache 構文の詳細は公式のマニュアルを参照してください。  
-> https://mustache.github.io/mustache.5.html
+> Handlebars 構文の詳細は公式のマニュアルを参照してください。  
+> https://handlebarsjs.com/guide/expressions.html
 
 ### `{{#trimWhitespace}} … {{/trimWhitespace}}`
 
@@ -198,8 +198,8 @@ Mustache テンプレートエンジンを使用しているため、任意の�
 - 説明: 最初のハンク/最後のハンクの場合のみ囲んだ内容を処理します。
 
 > [!TIP]
-> Section は条件を反転 (Inverted Section) させることもできます。詳細は公式のマニュアルを参照してください。  
-> https://mustache.github.io/mustache.5.html#Inverted-Sections
+> 条件を反転させることもできます。詳細は公式のマニュアルを参照してください。  
+> https://handlebarsjs.com/guide/builtin-helpers.html#unless
 
 ## テンプレートの例
 
@@ -207,7 +207,7 @@ Mustache テンプレートエンジンを使用しているため、任意の�
 
 以下はファイルパスや行番号を指定できるように拡張した Markdown コードブロックのためのテンプレートです。
 
-````mustache
+````handlebars
 {{#hunkList}}
 {{#collapseWhitespace}}```{{langId}} {{#isFirst}}filePath={{filePath}}{{/isFirst}} newStart={{newStart}} oldStart={{oldStart}}{{/collapseWhitespace}}
 {{{code}}}

--- a/entrypoints/popup/components/TemplateFormDialog.tsx
+++ b/entrypoints/popup/components/TemplateFormDialog.tsx
@@ -6,7 +6,6 @@ import {
   TextInput,
 } from "@primer/react"
 import { Banner } from "@primer/react/experimental"
-import mustache from "mustache"
 import { FormEvent, useEffect, useState } from "react"
 
 interface TemplateFormDialogProps {
@@ -62,10 +61,20 @@ export const TemplateFormDialog = ({
     }
 
     try {
-      mustache.parse(source)
+      const response = await retry(() =>
+        sendMessage(
+          "validate",
+          { templateSource: source },
+          ensureSandboxContentWindow(),
+        ),
+      )
+
+      if (!response.success) {
+        newErrors.source = response.error
+      }
     } catch (err) {
       newErrors.source =
-        err instanceof Error ? err.message : "Invalid Mustache syntax"
+        err instanceof Error ? err.message : "Invalid Handlebars syntax"
     }
 
     if (Object.keys(newErrors).length) {
@@ -143,7 +152,7 @@ export const TemplateFormDialog = ({
             />
             {validated && errors.name && (
               <FormControl.Validation variant="error">
-                {errors.name}
+                <span style={{ whiteSpace: "pre-wrap" }}>{errors.name}</span>
               </FormControl.Validation>
             )}
           </FormControl>
@@ -166,7 +175,7 @@ export const TemplateFormDialog = ({
             />
             {validated && errors.source && (
               <FormControl.Validation variant="error">
-                {errors.source}
+                <span style={{ whiteSpace: "pre-wrap" }}>{errors.source}</span>
               </FormControl.Validation>
             )}
           </FormControl>

--- a/entrypoints/template-renderer.sandbox/index.html
+++ b/entrypoints/template-renderer.sandbox/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Template Renderer Sandbox</title>
+  </head>
+  <body>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/entrypoints/template-renderer.sandbox/main.ts
+++ b/entrypoints/template-renderer.sandbox/main.ts
@@ -1,0 +1,41 @@
+const renderer = getTemplateRenderer()
+
+window.addEventListener("message", (event) => {
+  const { command, messageId, message } = event.data
+
+  const sendMessage = <K extends keyof SandboxMessageMap>(message: SandboxMessageMap[K]["res"]) => {
+    if (event.source) {
+      event.source.postMessage(
+        { command, messageId, message },
+        { targetOrigin: event.origin },
+      )
+    } else {
+      throw new Error("Message emitter not found")
+    }
+  }
+
+  switch (command) {
+    case "render":
+      try {
+        const result = renderer.render(message.templateSource, message.context)
+        sendMessage({ success: true, result })
+      } catch (error) {
+        sendMessage({
+          success: false,
+          error: error instanceof Error ? error.message : "Unknown error",
+        })
+      }
+      break
+    case "validate":
+      try {
+        renderer.validate(message.templateSource)
+        sendMessage({ success: true })
+      } catch (error) {
+        sendMessage({
+          success: false,
+          error: error instanceof Error ? error.message : "Unknown error",
+        })
+      }
+      break
+  }
+})

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "@webext-core/messaging": "2.3.0",
     "@webext-core/proxy-service": "1.2.1",
     "diff": "8.0.2",
+    "handlebars": "4.7.8",
     "idb": "8.0.3",
-    "mustache": "4.2.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "styled-components": "5.3.11"
@@ -42,7 +42,6 @@
     "@eslint/js": "9.30.1",
     "@playwright/test": "1.54.2",
     "@types/chrome": "0.0.332",
-    "@types/mustache": "4.2.6",
     "@types/react": "19.1.8",
     "@types/react-dom": "19.1.6",
     "@types/styled-components": "5.1.34",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,12 +29,12 @@ importers:
       diff:
         specifier: 8.0.2
         version: 8.0.2
+      handlebars:
+        specifier: 4.7.8
+        version: 4.7.8
       idb:
         specifier: 8.0.3
         version: 8.0.3
-      mustache:
-        specifier: 4.2.0
-        version: 4.2.0
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -54,9 +54,6 @@ importers:
       '@types/chrome':
         specifier: 0.0.332
         version: 0.0.332
-      '@types/mustache':
-        specifier: 4.2.6
-        version: 4.2.6
       '@types/react':
         specifier: 19.1.8
         version: 19.1.8
@@ -769,9 +766,6 @@ packages:
 
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
-
-  '@types/mustache@4.2.6':
-    resolution: {integrity: sha512-t+8/QWTAhOFlrF1IVZqKnMRJi84EgkIK5Kh0p2JV4OLywUvCwJPFxbJAl7XAow7DVIHsF+xW9f1MVzg0L6Szjw==}
 
   '@types/node@24.6.2':
     resolution: {integrity: sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==}
@@ -1757,6 +1751,11 @@ packages:
   growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
 
+  handlebars@4.7.8:
+    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2260,10 +2259,6 @@ packages:
     resolution: {integrity: sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  mustache@4.2.0:
-    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
-    hasBin: true
-
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -2278,6 +2273,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
@@ -3006,6 +3004,11 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
   uhyphen@0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
@@ -3232,6 +3235,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -3896,8 +3902,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/minimatch@3.0.5': {}
-
-  '@types/mustache@4.2.6': {}
 
   '@types/node@24.6.2':
     dependencies:
@@ -5102,6 +5106,15 @@ snapshots:
 
   growly@1.3.0: {}
 
+  handlebars@4.7.8:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   has-bigints@1.1.0: {}
 
   has-flag@3.0.0: {}
@@ -5566,8 +5579,6 @@ snapshots:
       array-union: 3.0.1
       minimatch: 3.1.2
 
-  mustache@4.2.0: {}
-
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -5579,6 +5590,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  neo-async@2.6.2: {}
 
   node-fetch-native@1.6.7: {}
 
@@ -6432,6 +6445,9 @@ snapshots:
 
   ufo@1.6.1: {}
 
+  uglify-js@3.19.3:
+    optional: true
+
   uhyphen@0.2.0: {}
 
   uid@2.0.2:
@@ -6697,6 +6713,8 @@ snapshots:
   winreg@0.0.12: {}
 
   word-wrap@1.2.5: {}
+
+  wordwrap@1.0.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "./fixtures"
 
 const EXPECTED_CLIPBOARD_TEXT = `
 <!-- Sample template -->
-\`\`\`diff-tsx filePath=entrypoints&#x2F;github.content&#x2F;index.tsx newStart=39 oldStart=39
+\`\`\`diff-tsx filePath=entrypoints/github.content/index.tsx newStart=39 oldStart=39
  
      await executeIfMatched(location)
  

--- a/tests/e2e/pages/popup.ts
+++ b/tests/e2e/pages/popup.ts
@@ -163,28 +163,28 @@ export async function openPopup(page: Page, extensionId: string) {
 
     // MARK: - 待機処理
 
-    async waitForFormDialog(timeout = 500) {
+    async waitForFormDialog(timeout = 3000) {
       await page.locator('[role="dialog"]').waitFor({
         state: "visible",
         timeout,
       })
     },
 
-    async waitForFormDialogToClose(timeout = 500) {
+    async waitForFormDialogToClose(timeout = 3000) {
       await page.locator('[role="dialog"]').waitFor({
         state: "hidden",
         timeout,
       })
     },
 
-    async waitForConfirmDialog(timeout = 500) {
+    async waitForConfirmDialog(timeout = 3000) {
       await page.locator('[role="alertdialog"]').waitFor({
         state: "visible",
         timeout,
       })
     },
 
-    async waitForConfirmDialogToClose(timeout = 500) {
+    async waitForConfirmDialogToClose(timeout = 3000) {
       await page.locator('[role="alertdialog"]').waitFor({
         state: "hidden",
         timeout,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -9,3 +9,10 @@ vi.mock("idb", () => ({
 vi.mock("@webext-core/proxy-service", () => ({
   defineProxyService: vi.fn(() => [vi.fn(), vi.fn()]),
 }))
+
+// wxt/browser のモック
+vi.mock("wxt/browser", async () => {
+  const { fakeBrowser } = await import("wxt/testing")
+  fakeBrowser.runtime.getManifest = vi.fn(() => ({}))
+  return { browser: fakeBrowser }
+})

--- a/utils/sandbox.ts
+++ b/utils/sandbox.ts
@@ -1,0 +1,66 @@
+let sandbox: HTMLIFrameElement | null = null
+
+export const ensureSandboxContentWindow = (): Window => {
+  if (sandbox) {
+    return sandbox.contentWindow!
+  }
+
+  sandbox = document.createElement("iframe")
+  sandbox.src = browser.runtime.getURL("/template-renderer.html")
+  sandbox.style.display = "none"
+  document.body.appendChild(sandbox)
+
+  return sandbox.contentWindow!
+}
+
+export async function retry<T>(
+  task: () => T | Promise<T>,
+  baseMs = 500,
+  attempts = 5,
+): Promise<T> {
+  try {
+    return await Promise.try(task)
+  } catch (error) {
+    if (attempts < 1) throw error
+    await new Promise((resolve) => setTimeout(resolve, baseMs))
+    return retry(task, attempts - 1, baseMs * 2)
+  }
+}
+
+export type SandboxMessageMap = {
+  render: {
+    req: { templateSource: string; context: unknown }
+    res: { success: true; result: string } | { success: false; error: string }
+  }
+  validate: {
+    req: { templateSource: string }
+    res: { success: true } | { success: false; error: string }
+  }
+}
+
+// TODO: AbortSignal に対応する
+export const sendMessage = <K extends keyof SandboxMessageMap>(
+  command: K,
+  message: SandboxMessageMap[K]["req"],
+  targetWindow: Window = window,
+  targetOrigin: string = "*",
+): Promise<SandboxMessageMap[K]["res"]> =>
+  new Promise((resolve, reject) => {
+    const messageId = crypto.randomUUID()
+    const timeoutId = setTimeout(() => {
+      cleanUp()
+      reject(new Error(`Request timed out`))
+    }, 50) // リトライを考慮して短めに設定
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data.messageId === messageId) {
+        cleanUp()
+        resolve(event.data.message)
+      }
+    }
+    const cleanUp = () => {
+      window.removeEventListener("message", handleMessage)
+      clearTimeout(timeoutId)
+    }
+    window.addEventListener("message", handleMessage)
+    targetWindow.postMessage({ command, messageId, message }, targetOrigin)
+  })

--- a/utils/templateRenderer.ts
+++ b/utils/templateRenderer.ts
@@ -1,0 +1,82 @@
+import Handlebars from "handlebars"
+
+export interface TemplateRenderer {
+  /**
+   * テンプレートをレンダリングする
+   * @param templateSource テンプレートコード
+   * @param context テンプレートコンテキスト
+   * @returns レンダリング結果
+   */
+  render(templateSource: string, context: Record<string, unknown>): string
+
+  /**
+   * テンプレートの構文を検証する
+   * @param templateSource テンプレートコード
+   */
+  validate(templateSource: string): void
+}
+
+export const createTemplateRenderer = (): TemplateRenderer => {
+  Handlebars.registerHelper(
+    "trimWhitespace",
+    function (this: unknown, options) {
+      return options.fn(this).trim()
+    },
+  )
+  Handlebars.registerHelper(
+    "collapseWhitespace",
+    function (this: unknown, options) {
+      return options.fn(this).replace(/\s+/g, " ")
+    },
+  )
+
+  const DUMMY_CONTEXT = {
+    isAdded: false,
+    isDeleted: false,
+    isModified: true,
+    hunkList: [
+      {
+        code: " line2\n line3\n line4\n-line5\n line6\n line7\n line8",
+        langId: "diff-txt",
+        filePath: "text.txt",
+        fileName: "text.txt",
+        newStart: 2,
+        oldStart: 2,
+        isFirst: true,
+        isLast: false,
+      },
+      {
+        code: " line12\n line13\n line14\n-line15",
+        langId: "diff-txt",
+        filePath: "text.txt",
+        fileName: "text.txt",
+        newStart: 11,
+        oldStart: 12,
+        isFirst: false,
+        isLast: true,
+      },
+    ],
+  }
+
+  return {
+    render(templateSource: string, context: Record<string, unknown>): string {
+      const template = Handlebars.compile(templateSource)
+      return template(context)
+    },
+
+    validate(templateSource: string): void {
+      const template = Handlebars.compile(templateSource)
+      template(DUMMY_CONTEXT) // 多くの構文エラーは実行時に発生するため、ダミーコンテキストで試してみる
+    },
+  }
+}
+
+let globalRenderer: TemplateRenderer | null = null
+
+export const getTemplateRenderer = (): TemplateRenderer => {
+  if (!globalRenderer) {
+    globalRenderer = createTemplateRenderer()
+  }
+
+  return globalRenderer
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -13,5 +13,26 @@ export default defineConfig({
   manifest: {
     host_permissions: ["*://*.github.com/*", "*://*.githubusercontent.com/*"],
     permissions: ["downloads"],
+    /*
+     * コンテンツスクリプトからサンドボックスを読み込むために必要
+     * ポップアップの場合は不要
+     */
+    web_accessible_resources: [
+      {
+        resources: ["template-renderer.html"],
+        matches: ["*://*.github.com/*"],
+      },
+    ],
   },
+  /*
+   * 開発環境のみ必要
+   * サンドボックスから Vite 開発サーバーのモジュールを読み込む際の CORS ブロックを回避する
+   */
+  vite: () => ({
+    server: {
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+    },
+  }),
 })


### PR DESCRIPTION
この PR の変更は Mustache テンプレートとの互換性を保てるところまでにする。
resolve #9 